### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/templates/sechub-workshop-setup-template.json
+++ b/templates/sechub-workshop-setup-template.json
@@ -441,7 +441,7 @@
                 },
                 "Description": "Function to take a finding from SecHub and send it to Slack",
                 "FunctionName": "sechub-to-slack",
-                "Runtime": "nodejs12.x",
+                "Runtime": "nodejs16.x",
                 "Handler": "sechub-to-slack.handler",
                 "Role": {
                     "Fn::GetAtt": [


### PR DESCRIPTION
CloudFormation templates in aws-security-hub-workshop have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.