### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/templates/inspector-template.json
+++ b/templates/inspector-template.json
@@ -160,7 +160,7 @@
                 },
                 "Description": "Function that runs an inspector assessment",
                 "FunctionName": "inspector-run-assessment",
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Handler": "inspector-run-assessment.lambda_handler",
                 "Role": {
                         "Fn::GetAtt": [

--- a/templates/inspector_template.json
+++ b/templates/inspector_template.json
@@ -182,7 +182,7 @@
                 },
                	"Description": "Function that runs an inspector assessment",
                	"FunctionName": "inspector-run-assessment",
-               	"Runtime": "python3.7",
+               	"Runtime": "python3.10",
               	"Handler": "inspector-run-assessment.lambda_handler",
               	"Role": {
                         "Fn::GetAtt": [

--- a/templates/sechub-workshop-setup-template.json
+++ b/templates/sechub-workshop-setup-template.json
@@ -376,7 +376,7 @@
                 },
                 "Description": "Function that swaps the security groups on an EC2 instance.",
                 "FunctionName": "isolate-ec2-security-group",
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Handler": "isolate-ec2-security-group.lambda_handler",
                 "Role": {
                     "Fn::GetAtt": [
@@ -596,7 +596,7 @@
                 },
                 "Description": "Function to raise SecHub findings for non-compliant AMIs",
                 "FunctionName": "ec2-non-compliant-ami-sechub",
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Handler": "ec2-non-compliant-ami-sechub.lambda_handler",
                 "Role": {
                     "Fn::GetAtt": [
@@ -1014,7 +1014,7 @@
                 },
                 "Description": "Enrich Finding with EC2 Instance Tags - Automating Security Workshop.",
                 "FunctionName": "enrich-sec-hub-finding",
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Handler": "enrich-sec-hub-finding.lambda_handler",
                 "Role": {
                     "Fn::GetAtt": [

--- a/templates/secrets-manager-template.json
+++ b/templates/secrets-manager-template.json
@@ -169,7 +169,7 @@
                 },
                 "Description": "Function to raise SecHub findings for non-compliant secrets",
                 "FunctionName": "find-secrets-without-rotation",
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Handler": "find-secrets-without-rotation.lambda_handler",
                 "Role": {
                     "Fn::GetAtt": [


### PR DESCRIPTION
CloudFormation templates in aws-security-hub-workshop have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.